### PR TITLE
Added back C++ tests on osx

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -34,10 +34,8 @@ steps:
     workingDirectory: $(Build.BinariesDirectory)/build
 
   - script: |
-      if [[ $(osx_platform) != 1 ]]; then
-        source activate xtensor-r
-        ./test_xtensor_r
-      fi
+      source activate xtensor-r
+      ./test_xtensor_r
     displayName: Run C++ tests
     workingDirectory: $(Build.BinariesDirectory)/build/test
 


### PR DESCRIPTION
This PR shows the segmentation fault of the C++ tests on `macOS_10_15`