### PR TITLE
add rank member to rtensor and rarray

### DIFF
--- a/include/xtensor-r/rarray.hpp
+++ b/include/xtensor-r/rarray.hpp
@@ -106,6 +106,8 @@ namespace xt
 
         constexpr static int SXP = Rcpp::traits::r_sexptype_traits<T>::rtype;
 
+        constexpr static std::size_t rank = SIZE_MAX;
+
         rarray() = default;
         rarray(SEXP exp);
 

--- a/include/xtensor-r/rtensor.hpp
+++ b/include/xtensor-r/rtensor.hpp
@@ -93,6 +93,8 @@ namespace xt
 
         constexpr static int SXP = Rcpp::traits::r_sexptype_traits<T>::rtype;
 
+        constexpr static std::size_t rank = N;
+
         rtensor();
         rtensor(nested_initializer_list_t<T, N> t);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,7 @@ set(XTENSOR_R_TESTS
     test_roptional.cpp
     test_rtensor.cpp
     test_rvectorize.cpp
+    test_sfinae.cpp
 )
 
 add_executable(test_xtensor_r ${XTENSOR_R_TESTS} ${XTENSOR_R_HEADERS})

--- a/test/test_sfinae.cpp
+++ b/test/test_sfinae.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+* Copyright (c) Wolf Vollprecht, Johan Mabille and Sylvain Corlay          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "xtensor-r/rtensor.hpp"
+#include "xtensor-r/rarray.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+
+namespace xt
+{
+    template <class E, std::enable_if_t<!xt::has_fixed_rank_t<E>::value, int> = 0>
+    inline bool sfinae_has_fixed_rank(E&&)
+    {
+        return false;
+    }
+
+    template <class E, std::enable_if_t<xt::has_fixed_rank_t<E>::value, int> = 0>
+    inline bool sfinae_has_fixed_rank(E&&)
+    {
+        return true;
+    }
+
+    TEST(sfinae, fixed_rank)
+    {
+        xt::rarray<int> a = {{9, 9, 9}, {9, 9, 9}};
+        xt::rtensor<int, 1> b = {9, 9};
+        xt::rtensor<int, 2> c = {{9, 9}, {9, 9}};
+
+        EXPECT_TRUE(sfinae_has_fixed_rank(a) == false);
+        EXPECT_TRUE(sfinae_has_fixed_rank(b) == true);
+        EXPECT_TRUE(sfinae_has_fixed_rank(c) == true);
+    }
+
+    TEST(sfinae, get_rank)
+    {
+        xt::rtensor<double, 1> A = xt::zeros<double>({2});
+        xt::rtensor<double, 2> B = xt::zeros<double>({2, 2});
+        xt::rarray<double> C = xt::zeros<double>({2, 2});
+
+        EXPECT_TRUE(xt::get_rank<decltype(A)>::value == 1ul);
+        EXPECT_TRUE(xt::get_rank<decltype(B)>::value == 2ul);
+        EXPECT_TRUE(xt::get_rank<decltype(C)>::value == SIZE_MAX);
+    }
+}


### PR DESCRIPTION
Hi,

I noticed that `rtensor` and `rarray` did not have a `rank` member such that 
```cpp 
xt::get_rank<xt::rtensor<double, 2>>::value
```
returns `SIZE_MAX` instead of `2`.

So this PR adds a `rank` member to these objects, taking inspiration from the one made for `xtensor-python` (https://github.com/xtensor-stack/xtensor-python/pull/241).